### PR TITLE
Added Avatar component

### DIFF
--- a/src/components/Common/Avatar/index.tsx
+++ b/src/components/Common/Avatar/index.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+
+interface Props {
+	url?: string
+	name?: string
+}
+
+const Avatar: FC<Props> = ({ url = 'http://www.gravatar.com/avatar/?d=mp', name }) => {
+	return (
+		<AvatarCircle url={url} title={name} />
+	)
+}
+
+export default Avatar
+
+const AvatarCircle = styled.div<Props>`
+	display: inline-block;
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	border: 2px solid #fff;
+	margin-right: -7px;
+	overflow: hidden;
+	background: url(${({ url }) => url}) no-repeat center / cover;
+`


### PR DESCRIPTION
Added the Avatar component that accepts url and name parameters, if a url is not specified it will show the default gravatar. We can use [Pravatar](https://pravatar.cc/) to generate user images (at the correct size and with unique id's) later when this component is being used while rendering the list of assigned members.